### PR TITLE
'raw' and 'endraw' are unnecessary in hugo

### DIFF
--- a/content/writing/docker-alias.markdown
+++ b/content/writing/docker-alias.markdown
@@ -53,7 +53,7 @@ $ dl
 コンテナのIPを取得する．
 
 ```bash
-alias dip="docker inspect --format {% raw %} '{{ .NetworkSettings.IPAddress }}' {% endraw %}"
+alias dip="docker inspect --format '{{ .NetworkSettings.IPAddress }}'"
 ```
 
 ```bash

--- a/content/writing/docker-network.markdown
+++ b/content/writing/docker-network.markdown
@@ -65,12 +65,12 @@ docker0   Link encap:Ethernet  HWaddr 7a:b1:e2:00:15:66
 ```
 
 ```bash
-$ docker inspect --format '{% raw %} {{ .NetworkSettings.IPAddress }} {% endraw %}' b9ffb0800ca5
+$ docker inspect --format '{{ .NetworkSettings.IPAddress }}' b9ffb0800ca5
 172.17.0.2
 ```
 
 ```bash
-$ docker inspect --format '{% raw %} {{ .NetworkSettings.IPAddress }} {% endraw %}' 4c0d9b786e8f
+$ docker inspect --format '{{ .NetworkSettings.IPAddress }}' 4c0d9b786e8f
 172.17.0.3
 ```
 

--- a/content/writing/docker-serf.markdown
+++ b/content/writing/docker-serf.markdown
@@ -95,7 +95,7 @@ $ docker run -d -t \
 $ docker run -d -t \
     --name serf2 \
     tcnksm/serf \
-    serf agent -join $(docker inspect --format '{% raw %} {{ .NetworkSettings.IPAddress }} {% endraw %}' 06b0325f6373):7979
+    serf agent -join $(docker inspect --format '{{ .NetworkSettings.IPAddress }}' 06b0325f6373):7979
 ```
 
 `--format`指定するとIPだけを抜き出せる．

--- a/content/writing/github-release.markdown
+++ b/content/writing/github-release.markdown
@@ -21,7 +21,7 @@ categories: golang
 gox \
     -os="darwin linux windows" \
     -arch="386 amd64" \
-    -output "{%raw%} pkg/{{.OS}}_{{.Arch}}/{{.Dir}} {%endraw%}"
+    -output "pkg/{{.OS}}_{{.Arch}}/{{.Dir}}"
 ```
 
 あとは，これらをzipでアーカイブする（[package.sh](https://github.com/tcnksm/go-compile-scripts/blob/master/package.sh)）．

--- a/content/writing/gox.markdown
+++ b/content/writing/gox.markdown
@@ -104,7 +104,7 @@ rm -rf pkg/
 gox \
     -os="${XC_OS}" \
     -arch="${XC_ARCH}" \
-    -output "{%raw%} pkg/{{.OS}}_{{.Arch}}/{{.Dir}} {%endraw%}"
+    -output "pkg/{{.OS}}_{{.Arch}}/{{.Dir}}"
 ```
 
 出力先は，`-output`で指定できる．フォーマットは，go templateに従う．

--- a/content/writing/haml-angular-js.markdown
+++ b/content/writing/haml-angular-js.markdown
@@ -30,7 +30,7 @@ index.haml
 
   %body
     %input{type: "text", "ng-model" => "name"}
-    %p Hello, {% raw %} {{ name }} {% endraw %}
+    %p Hello, {{ name }}
 ```
 
 htmlに整形
@@ -51,7 +51,7 @@ index.html
   </head>
   <body>
     <input ng-model='name' type='text'>
-    <p>Hello, {% raw %} {{ name }} {% endraw %}</p>
+    <p>Hello, {{ name }}</p>
   </body>
 </html>
 ```


### PR DESCRIPTION
There are `{{% raw %}}` and `{{% endraw %}}` in some posts.
For example, http://deeeet.com/writing/2014/07/23/github-release/ .

This confuses cut and paste user like me.

See
http://nathanleclaire.com/blog/2014/12/22/migrating-to-hugo-from-octopress/
