### PR TITLE
Add Edit button to blog posts

### DIFF
--- a/app/writing/[slug]/page.tsx
+++ b/app/writing/[slug]/page.tsx
@@ -96,6 +96,28 @@ export default function Blog({ params }) {
         <p className="text-sm text-neutral-600 dark:text-neutral-400">
           {formatDate(post.metadata.publishedAt)}
         </p>
+        <a
+          href={`https://github.com/tcnksm/deeeet.com/edit/main/app/writing/posts/${post.slug}.mdx`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-neutral-600 dark:text-neutral-400 hover:text-neutral-800 dark:hover:text-neutral-200 flex items-center gap-1"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+            <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+          </svg>
+          Edit
+        </a>
       </div>
       <article className="prose">
         <CustomMDX source={post.content} />


### PR DESCRIPTION
Adds an 'Edit' link with pencil icon on each blog post page that links directly to the GitHub edit page for that post's MDX file.

This allows quick editing of posts directly from the blog.