### PR TITLE
Add 'Read with Claude' button to blog posts

### DIFF
--- a/app/components/read-with-claude.tsx
+++ b/app/components/read-with-claude.tsx
@@ -16,11 +16,11 @@ Start with a tight summary: one paragraph, bulleted. Assume I have zero contextâ
       href={claudeUrl}
       target="_blank"
       rel="noopener noreferrer"
-      className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md bg-[#D97757] hover:bg-[#c4654a] text-white transition-colors"
+      className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded bg-[#D97757] hover:bg-[#c4654a] text-white transition-colors"
     >
       <svg
-        width="18"
-        height="18"
+        width="14"
+        height="14"
         viewBox="0 0 24 24"
         fill="currentColor"
         xmlns="http://www.w3.org/2000/svg"

--- a/app/components/read-with-claude.tsx
+++ b/app/components/read-with-claude.tsx
@@ -1,0 +1,34 @@
+export function ReadWithClaude({ 
+  articleUrl, 
+  articleTitle 
+}: { 
+  articleUrl: string; 
+  articleTitle: string;
+}) {
+  const prompt = `Hey! Got something cool for you—curious what you make of this: ${articleUrl}
+It's an article titled "${articleTitle}" and I want to understand it better.
+Start with a tight summary: one paragraph, bulleted. Assume I have zero context—actually make sure I get it, not just skim the surface. Then offer to go deeper on what's most interesting or relevant to me.`;
+
+  const claudeUrl = `https://claude.ai/new?q=${encodeURIComponent(prompt)}`;
+
+  return (
+    <a
+      href={claudeUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md bg-[#D97757] hover:bg-[#c4654a] text-white transition-colors"
+    >
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        {/* Anthropic Claude "asterisk" style icon */}
+        <path d="M12 2L13.5 8.5L20 7L15 12L20 17L13.5 15.5L12 22L10.5 15.5L4 17L9 12L4 7L10.5 8.5L12 2Z" />
+      </svg>
+      Read with Claude
+    </a>
+  );
+}

--- a/app/components/read-with-claude.tsx
+++ b/app/components/read-with-claude.tsx
@@ -34,7 +34,7 @@ export function ReadWithClaude({
         href={claudeUrl}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded border border-[#D97757] text-[#D97757] hover:bg-[#D97757] hover:text-white transition-colors"
+        className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded border border-[#D97757] text-neutral-800 dark:text-neutral-200 hover:bg-[#D97757] hover:text-white transition-colors"
       >
         Claude
         <ExternalLinkIcon />
@@ -43,7 +43,7 @@ export function ReadWithClaude({
         href={chatgptUrl}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded border border-[#10a37f] text-[#10a37f] hover:bg-[#10a37f] hover:text-white transition-colors"
+        className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded border border-[#10a37f] text-neutral-800 dark:text-neutral-200 hover:bg-[#10a37f] hover:text-white transition-colors"
       >
         ChatGPT
         <ExternalLinkIcon />

--- a/app/components/read-with-claude.tsx
+++ b/app/components/read-with-claude.tsx
@@ -1,3 +1,22 @@
+function ExternalLinkIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+      <polyline points="15 3 21 3 21 9" />
+      <line x1="10" y1="14" x2="21" y2="3" />
+    </svg>
+  );
+}
+
 export function ReadWithClaude({ 
   articleUrl, 
   articleTitle 
@@ -15,17 +34,19 @@ export function ReadWithClaude({
         href={claudeUrl}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded bg-[#D97757] hover:bg-[#c4654a] text-white transition-colors"
+        className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded border border-[#D97757] text-[#D97757] hover:bg-[#D97757] hover:text-white transition-colors"
       >
-        Read with Claude
+        Claude
+        <ExternalLinkIcon />
       </a>
       <a
         href={chatgptUrl}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded bg-[#10a37f] hover:bg-[#0d8a6a] text-white transition-colors"
+        className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded border border-[#10a37f] text-[#10a37f] hover:bg-[#10a37f] hover:text-white transition-colors"
       >
-        Read with ChatGPT
+        ChatGPT
+        <ExternalLinkIcon />
       </a>
     </div>
   );

--- a/app/components/read-with-claude.tsx
+++ b/app/components/read-with-claude.tsx
@@ -5,7 +5,7 @@ export function ReadWithClaude({
   articleUrl: string; 
   articleTitle: string;
 }) {
-  const prompt = `${articleTitle}\n${articleUrl}`;
+  const prompt = `${articleTitle}: ${articleUrl}`;
 
   const claudeUrl = `https://claude.ai/new?q=${encodeURIComponent(prompt)}`;
 

--- a/app/components/read-with-claude.tsx
+++ b/app/components/read-with-claude.tsx
@@ -6,17 +6,27 @@ export function ReadWithClaude({
   articleTitle: string;
 }) {
   const prompt = `${articleTitle}: ${articleUrl}`;
-
   const claudeUrl = `https://claude.ai/new?q=${encodeURIComponent(prompt)}`;
+  const chatgptUrl = `https://chat.openai.com/?q=${encodeURIComponent(prompt)}`;
 
   return (
-    <a
-      href={claudeUrl}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded bg-[#D97757] hover:bg-[#c4654a] text-white transition-colors"
-    >
-Read with Claude
-    </a>
+    <div className="flex gap-2">
+      <a
+        href={claudeUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded bg-[#D97757] hover:bg-[#c4654a] text-white transition-colors"
+      >
+        Read with Claude
+      </a>
+      <a
+        href={chatgptUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded bg-[#10a37f] hover:bg-[#0d8a6a] text-white transition-colors"
+      >
+        Read with ChatGPT
+      </a>
+    </div>
   );
 }

--- a/app/components/read-with-claude.tsx
+++ b/app/components/read-with-claude.tsx
@@ -18,17 +18,7 @@ Start with a tight summary: one paragraph, bulleted. Assume I have zero contextâ
       rel="noopener noreferrer"
       className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded bg-[#D97757] hover:bg-[#c4654a] text-white transition-colors"
     >
-      <svg
-        width="14"
-        height="14"
-        viewBox="0 0 64 64"
-        fill="currentColor"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        {/* Claude starburst icon */}
-        <path d="M32 0L35.5 24.5L56 8L43.5 28.5L64 32L43.5 35.5L56 56L35.5 43.5L32 64L28.5 43.5L8 56L20.5 35.5L0 32L20.5 28.5L8 8L28.5 24.5L32 0Z" />
-      </svg>
-      Read with Claude
+Read with Claude
     </a>
   );
 }

--- a/app/components/read-with-claude.tsx
+++ b/app/components/read-with-claude.tsx
@@ -21,12 +21,12 @@ Start with a tight summary: one paragraph, bulleted. Assume I have zero contextâ
       <svg
         width="14"
         height="14"
-        viewBox="0 0 24 24"
+        viewBox="0 0 64 64"
         fill="currentColor"
         xmlns="http://www.w3.org/2000/svg"
       >
-        {/* Anthropic Claude "asterisk" style icon */}
-        <path d="M12 2L13.5 8.5L20 7L15 12L20 17L13.5 15.5L12 22L10.5 15.5L4 17L9 12L4 7L10.5 8.5L12 2Z" />
+        {/* Claude starburst icon */}
+        <path d="M32 0L35.5 24.5L56 8L43.5 28.5L64 32L43.5 35.5L56 56L35.5 43.5L32 64L28.5 43.5L8 56L20.5 35.5L0 32L20.5 28.5L8 8L28.5 24.5L32 0Z" />
       </svg>
       Read with Claude
     </a>

--- a/app/components/read-with-claude.tsx
+++ b/app/components/read-with-claude.tsx
@@ -5,9 +5,7 @@ export function ReadWithClaude({
   articleUrl: string; 
   articleTitle: string;
 }) {
-  const prompt = `Hey! Got something cool for you—curious what you make of this: ${articleUrl}
-It's an article titled "${articleTitle}" and I want to understand it better.
-Start with a tight summary: one paragraph, bulleted. Assume I have zero context—actually make sure I get it, not just skim the surface. Then offer to go deeper on what's most interesting or relevant to me.`;
+  const prompt = `${articleTitle}\n${articleUrl}`;
 
   const claudeUrl = `https://claude.ai/new?q=${encodeURIComponent(prompt)}`;
 

--- a/app/writing/[slug]/page.tsx
+++ b/app/writing/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import { CustomMDX } from "app/components/mdx";
 import { formatDate, getBlogPosts } from "app/writing/utils";
 import { baseUrl } from "app/sitemap";
+import { ReadWithClaude } from "app/components/read-with-claude";
 
 export async function generateStaticParams() {
   let posts = getBlogPosts();
@@ -96,6 +97,14 @@ export default function Blog({ params }) {
         <p className="text-sm text-neutral-600 dark:text-neutral-400">
           {formatDate(post.metadata.publishedAt)}
         </p>
+      </div>
+      <div className="mb-8">
+        <ReadWithClaude 
+          articleUrl={`${baseUrl}/writing/${post.slug}`}
+          articleTitle={post.metadata.title}
+        />
+      </div>
+      <div className="flex justify-end items-center mb-4 text-sm">
         <a
           href={`https://github.com/tcnksm/deeeet.com/edit/main/app/writing/posts/${post.slug}.mdx`}
           target="_blank"

--- a/app/writing/[slug]/page.tsx
+++ b/app/writing/[slug]/page.tsx
@@ -104,7 +104,10 @@ export default function Blog({ params }) {
           articleTitle={post.metadata.title}
         />
       </div>
-      <div className="flex justify-end items-center mb-4 text-sm">
+      <article className="prose">
+        <CustomMDX source={post.content} />
+      </article>
+      <div className="flex justify-end items-center mt-8 text-sm">
         <a
           href={`https://github.com/tcnksm/deeeet.com/edit/main/app/writing/posts/${post.slug}.mdx`}
           target="_blank"
@@ -128,9 +131,6 @@ export default function Blog({ params }) {
           Edit
         </a>
       </div>
-      <article className="prose">
-        <CustomMDX source={post.content} />
-      </article>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

Add a 'Read with Claude' button to the top of blog posts, similar to [every.to's implementation](https://every.to/guides/agent-native).

## Changes

- Add `ReadWithClaude` component that links to claude.ai/new with the article URL and a summary prompt
- Place the button below the article date
- Move the Edit button to the end of the article
- Style the button with Claude's brand color (#D97757)

## Screenshot

The button appears at the top of each blog post and opens Claude with a pre-filled prompt asking for a summary of the article.
